### PR TITLE
FEATURE: Improved readonly support

### DIFF
--- a/code/ColorPaletteField.php
+++ b/code/ColorPaletteField.php
@@ -15,4 +15,32 @@ class ColorPaletteField extends OptionsetField
 
         return parent::Field($properties);
     }
+
+    /**
+     * Gets a readonly version of the field
+     * @return ColorPaletteField_Readonly
+     */
+    public function performReadonlyTransformation()
+    {
+		// Source and values are DataObject sets.
+		$field = $this->castedCopy('ColorPaletteField_Readonly');
+		$field->setSource($this->getSource());
+		$field->setReadonly(true);
+
+		return $field;
+	}
+}
+
+class ColorPaletteField_Readonly extends LookupField
+{
+    /**
+     * @param array $properties
+     * @return HTMLText
+     */
+    public function Field($properties = array())
+    {
+        Requirements::css(COLORPALETTE_DIR . '/css/ColorPaletteField.css');
+
+        return parent::Field($properties);
+    }
 }

--- a/code/GroupedColorPaletteField.php
+++ b/code/GroupedColorPaletteField.php
@@ -76,4 +76,53 @@ class GroupedColorPaletteField extends DropdownField
     {
         return 'groupedcolorpalette colorpalette';
     }
+
+    /**
+     * Gets a readonly version of the field
+     * @return GroupedColorPaletteField_Readonly
+     */
+    public function performReadonlyTransformation()
+    {
+		// Source and values are DataObject sets.
+		$field = $this->castedCopy('GroupedColorPaletteField_Readonly');
+		$field->setSource($this->getSource());
+		$field->setReadonly(true);
+
+		return $field;
+	}
+}
+
+class GroupedColorPaletteField_Readonly extends LookupField
+{
+    /**
+     * @param array $properties
+     * @return HTMLText
+     */
+    public function Field($properties = array())
+    {
+        Requirements::css(COLORPALETTE_DIR . '/css/ColorPaletteField.css');
+
+        return parent::Field($properties);
+    }
+    
+    /**
+     * Gets the label of the group that the color appears in
+     * @return string
+     */
+    public function getSelectedGroup()
+    {
+        $source = $this->getSource();
+        
+        if ($source) {
+            foreach($source as $groupName => $values) {
+                if (is_array($values)) {
+                    if (array_key_exists($this->value, $values)) {
+                        return $groupName;
+                    }
+                } else {
+                    throw new InvalidArgumentException('To use GroupedColorPaletteField you need to pass in an array of array\'s');
+                }
+            }
+        }
+    }
 }

--- a/css/ColorPaletteField.css
+++ b/css/ColorPaletteField.css
@@ -19,6 +19,10 @@
     outline: 1px solid #fff;
 }
 
+.colorpalette.readonly li label {
+    cursor: default;
+}
+
 .colorpalette li input:checked + label {
     outline: 5px solid #fff;
     position: relative;

--- a/templates/ColorPaletteField_Readonly.ss
+++ b/templates/ColorPaletteField_Readonly.ss
@@ -1,0 +1,6 @@
+<ul id="$ID" class="$extraClass">
+    <li>
+        <input name="$Name" type="hidden" value="$InputValue" />
+        <label for="$ID" style="background-color: $AttrValue"></label>
+    </li>
+</ul>

--- a/templates/GroupedColorPaletteField_Readonly.ss
+++ b/templates/GroupedColorPaletteField_Readonly.ss
@@ -1,0 +1,10 @@
+<% if $SelectedGroup %>
+    <h4>$SelectedGroup.XML</h4>
+<% end_if %>
+
+<ul id="$ID" class="$extraClass">
+    <li class="$Class">
+        <input name="$Name" type="hidden" value="$InputValue" />
+        <label for="$ID" style="background-color: $AttrValue"></label>
+    </li>
+</ul>


### PR DESCRIPTION
This pull adds an improved look to the readonly version of the fields, see attached screenshot. Basically rather than displaying the text label it pulls the color in as it would if it was editable but only shows the single option.
![readonly-color-palette](https://cloud.githubusercontent.com/assets/1391558/12584541/5c5c814c-c41e-11e5-9a24-1c027c3ecb07.png)
